### PR TITLE
Add 'show' attribute to YAxisOption for visibiity control

### DIFF
--- a/src/Options/YAxisOption.php
+++ b/src/Options/YAxisOption.php
@@ -25,7 +25,8 @@ class YAxisOption implements Arrayable
             'show' => $this->show ? 'true' : 'false',
             'min' => $this->min,
             'max' => $this->max,
-            'tickAmount' => $this->tickAmount
+            'tickAmount' => $this->tickAmount,
+            'show' => $this->show
         ];
     }
 }


### PR DESCRIPTION
Added the `show` attribute to the `toArray` method of the `YAxisOption` class, allowing for control over the Y-axis visibility in charts.