### PR TITLE
Updated y-axis label display

### DIFF
--- a/src/Options/YAxisOption.php
+++ b/src/Options/YAxisOption.php
@@ -22,7 +22,7 @@ class YAxisOption implements Arrayable
     public function toArray(): array
     {
         return [
-            'show' => $this->show ? 'true' : 'false',
+            'show' => $this->show,
             'min' => $this->min,
             'max' => $this->max,
             'tickAmount' => $this->tickAmount

--- a/tests/Feature/Options/YAxisOptionTest.php
+++ b/tests/Feature/Options/YAxisOptionTest.php
@@ -19,7 +19,7 @@ class YAxisOptionTest extends TestCase
 
         $yAxis = $options['yaxis'];
 
-        $this->assertSame('true', $yAxis['show']);
+        $this->assertSame(true, $yAxis['show']);
         $this->assertSame(0, $yAxis['min']);
         $this->assertSame(10, $yAxis['max']);
         $this->assertSame(1, $yAxis['tickAmount']);
@@ -36,7 +36,7 @@ class YAxisOptionTest extends TestCase
 
         $yAxis = $options['yaxis'];
 
-        $this->assertSame('true', $yAxis['show']);
+        $this->assertSame(true, $yAxis['show']);
         $this->assertSame(0, $yAxis['min']);
         $this->assertSame(10, $yAxis['max']);
         $this->assertSame(10, $yAxis['tickAmount']);


### PR DESCRIPTION
Changed code to directly use the value of $this->show instead of using a ternary operator.